### PR TITLE
Tk fix for volunteers menu

### DIFF
--- a/functions/session.inc
+++ b/functions/session.inc
@@ -206,9 +206,9 @@ function loadAccount($accountId)
     $_SESSION['customFields']['hotelRoomCheckIn'] = &$_SESSION['customFields'][search_definedFields('Check In')];
     $_SESSION['customFields']['hotelRoomCheckOut'] = &$_SESSION['customFields'][search_definedFields('Check Out')];
 
-    // If the logged in user is volunteers, note it
-    if (strpos($_SESSION['customFields']['currConComPos'][0], 'Volunteers') !== false) {
-        $_SESSION['IS_VOLUNTEERS'] = true;
+    // If the logged in user is in the volunteers, note it
+    if (function_exists('VOLUNTEERS::_inVolunteers')) {
+        $_SESSION['IS_VOLUNTEERS'] = VOLUNTEERS::_inVolunteers($accountId);
     }
 
     // If the logged in user is a System Admin (defined in the config file), note it

--- a/functions/session.inc
+++ b/functions/session.inc
@@ -207,8 +207,8 @@ function loadAccount($accountId)
     $_SESSION['customFields']['hotelRoomCheckOut'] = &$_SESSION['customFields'][search_definedFields('Check Out')];
 
     // If the logged in user is in the volunteers, note it
-    if (function_exists('VOLUNTEERS::_inVolunteers')) {
-        $_SESSION['IS_VOLUNTEERS'] = VOLUNTEERS::_inVolunteers($accountId);
+    if (function_exists('VOLUNTEERS::inVolunteers')) {
+        $_SESSION['IS_VOLUNTEERS'] = VOLUNTEERS::inVolunteers($accountId);
     }
 
     // If the logged in user is a System Admin (defined in the config file), note it

--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -4,6 +4,23 @@ require_once($FUNCTIONDIR.'/divisional.inc');
 require_once($FUNCTIONDIR."/database.inc");
 require_once($FUNCTIONDIR.'/users.inc');
 
+class VOLUNTEERS {
+
+    public static function _inVolunteers($lookup)
+    {
+        $sql = "SELECT count($ListRecordID) From ConComList";
+        $sql .= " WHERE AccountID = $lookup;";
+        $result = DB::run($sql);
+        $value = $result->fetch();
+        if ($value !== 0) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+}
 
 function getDivision($dep)
 {
@@ -17,7 +34,6 @@ function getDepartmentEmails($dep)
     return($GLOBALS['Departments'][$dep]['Email']);
 
 }
-
 
 function getPositionID($position)
 {

--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -6,11 +6,11 @@ require_once($FUNCTIONDIR.'/users.inc');
 
 class VOLUNTEERS {
 
-    public static function _inVolunteers($lookup)
+    public static function inVolunteers($lookup)
     {
         $sql = "SELECT count($ListRecordID) From ConComList";
         $sql .= " WHERE AccountID = $lookup";
-        $sql .=" AND DepartmentID = 156;";
+        $sql .=" AND DepartmentID = (SELECT DepartmentID FROM Departments WHERE Name = 'Volunteers');";
         $result = DB::run($sql);
         $value = $result->fetch();
         if ($value !== 0) {

--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -9,7 +9,8 @@ class VOLUNTEERS {
     public static function _inVolunteers($lookup)
     {
         $sql = "SELECT count($ListRecordID) From ConComList";
-        $sql .= " WHERE AccountID = $lookup;";
+        $sql .= " WHERE AccountID = $lookup";
+        $sql .=" AND DepartmentID = 156;";
         $result = DB::run($sql);
         $value = $result->fetch();
         if ($value !== 0) {

--- a/modules/volunteers/pages/menubar.inc
+++ b/modules/volunteers/pages/menubar.inc
@@ -9,7 +9,7 @@ if (isset($_SESSION['customFields']['currConComPos'])) {
      'responsive' => true);
 }
 
-if (isset($_SESSION['IS_VOLUNTEERS']) || isset($_SESSION['IS_ADMIN'])) {
+if (!empty($_SESSION['IS_VOLUNTEERS']) || !empty($_SESSION['IS_ADMIN'])) {
     $basecolor = 'w3-yellow';
     if (array_key_exists('CIAB_VOLUNTEERADMIN', $_COOKIE) &&
        $_COOKIE["CIAB_VOLUNTEERADMIN"]) {


### PR DESCRIPTION
Previoiusly, IS_VOLUNTEERS (in the _SESSION) was set by looking up in neon.  The concom list is now kept in the DB, neon data is stale and not right anymore.  Moving to the volunteer class to lookup without needing globals.