### PR TITLE
Update DumpConComList to include aliases

### DIFF
--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -310,7 +310,9 @@ function DumpConComList()
     $email = array_unique(array_column($db_staff, 'Email'));
 
     foreach ($Departments as $kdep => $dep) {
-        array_push($email, $dep['Email'][0]);
+        foreach ($dep['Email'] as $listEmails) {
+            array_push($email, $listEmails);
+        }
     }
 
     foreach ($Divisions as $div) {


### PR DESCRIPTION
aliased departments are getting dropped from the google group because the aliases will SOMETIMES show before the department's main email.  I opted for this version instead of calling "not alias" because some of these groups are not the same users in the end.  AFTER the email fix on the google apps domain, this might need to switch to no-alias, but I don't want to decide that until we know the final form of the email domain