### PR TITLE
Add support for department emails being arrays

### DIFF
--- a/modules/concom/functions/concom.inc
+++ b/modules/concom/functions/concom.inc
@@ -311,7 +311,7 @@ function DumpConComList()
 
     foreach ($Departments as $kdep => $dep) {
         foreach ($dep['Email'] as $listEmails) {
-            array_push($email, $listEmails);
+            array_push($email, $listEmails['EMail']);
         }
     }
 


### PR DESCRIPTION
When getDepartmentEmails() changed to returning an array (good thing), this function needed to update to support the extra level of array.  This is a minor fix and only affects the deeplink automation for google groups.